### PR TITLE
[libsodium] Initial plan and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# libsodium
+
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.libsodium?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=166&branchName=master)
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/controls/libsodium_exists.rb
+++ b/controls/libsodium_exists.rb
@@ -1,0 +1,32 @@
+title 'Tests to confirm libsodium libraries exist'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input("plan_name", value: "libsodium")
+plan_ident = "#{plan_origin}/#{plan_name}"
+
+control 'core-plans-libsodium' do
+  impact 1.0
+  title 'Ensure libsodium libraries exist as expected'
+  desc '
+  We check that the three folders that libsodium installs are present.
+  '
+
+  hab_pkg_path = command("hab pkg path #{plan_ident}")
+  describe hab_pkg_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty}
+  end
+
+  describe command("ls #{File.join(hab_pkg_path.stdout.strip, "include")}") do
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+    its('exit_status') { should eq 0 }
+  end
+
+  describe command("ls #{File.join(hab_pkg_path.stdout.strip, "lib")}") do
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+    its('exit_status') { should eq 0 }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: libsodium
+title: Habitat Core Plan libsodium
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan libsodium
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.ps1
+++ b/plan.ps1
@@ -1,0 +1,34 @@
+$pkg_name="libsodium"
+$pkg_origin="core"
+$pkg_version="1.0.18"
+$_pkg_version_text=($pkg_version).Replace(".", "_")
+$pkg_description="Sodium is a new, easy-to-use software library for encryption, decryption, signatures, password hashing and more. It is a portable, cross-compilable, installable, packageable fork of NaCl, with a compatible API, and an extended API to improve usability even further."
+$pkg_upstream_url="https://github.com/jedisct1/libsodium"
+$pkg_license=@("ISC")
+$pkg_source="https://github.com/jedisct1/libsodium/archive/$pkg_version.zip"
+$pkg_shasum="1b72c0cdbc535ce42e14ac15e8fc7c089a3ee9ffe5183399fd77f0f3746ea794"
+$pkg_build_deps=@("core/visual-cpp-build-tools-2015")
+$pkg_bin_dirs=@("bin")
+$pkg_lib_dirs=@("lib")
+$pkg_include_dirs=@("include")
+
+function Invoke-SetupEnvironment {
+    . "$(Get-HabPackagePath visual-cpp-build-tools-2015)\setenv.ps1"
+}
+
+function Invoke-Build {
+    Set-Location "$pkg_name-$pkg_version"
+    msbuild.exe /m /p:Configuration=DynRelease /p:Platform=x64 builds/msvc/vs2015/libsodium.sln
+    if($LASTEXITCODE -ne 0) { Write-Error "msbuild failed!" }
+}
+
+function Invoke-Install {
+    $build_path = "$HAB_CACHE_SRC_PATH\$pkg_name-$pkg_version\$pkg_name-$pkg_version"
+
+    Copy-Item "$build_path\bin\x64\Release\v140\dynamic\libsodium.dll" "$pkg_prefix\bin\" -Force
+    Copy-Item "$build_path\bin\x64\Release\v140\dynamic\libsodium.lib" "$pkg_prefix\lib\" -Force
+    Copy-Item "$build_path\bin\x64\Release\v140\dynamic\libsodium.lib" "$pkg_prefix\lib\sodium.lib" -Force
+    Copy-Item "$build_path\src\$pkg_name\include\*.h" "$pkg_prefix\include\" -Force
+    mkdir "$pkg_prefix\include\sodium\"
+    Copy-Item "$build_path\src\$pkg_name\include\sodium\*.h" "$pkg_prefix\include\sodium\" -Force
+}

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,33 @@
+pkg_name=libsodium
+pkg_origin=core
+pkg_version=1.0.18
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+Sodium is a new, easy-to-use software library for encryption, decryption, \
+signatures, password hashing and more. It is a portable, cross-compilable, \
+installable, packageable fork of NaCl, with a compatible API, and an extended \
+API to improve usability even further.\
+"
+pkg_upstream_url="https://github.com/jedisct1/libsodium"
+pkg_license=('ISC')
+pkg_source="https://download.libsodium.org/libsodium/releases/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="6f504490b342a4f8a4c4a02fc9b866cbef8622d5df4e5452b46be121e46636c1"
+pkg_deps=(
+  core/glibc
+)
+pkg_build_deps=(
+  core/autoconf
+  core/automake
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_check() {
+  make check
+}


### PR DESCRIPTION
Profile: Habitat Core Plan libsodium (libsodium)
Version: 0.1.0
Target:  docker://18fca9a3ad08b11e5e4dcdbb0fb467469bb0149981e77f028556d4bf1c743492

  ✔  core-plans-libsodium: Ensure libsodium libraries exist as expected
     ✔  Command: `hab pkg path mindnumbing/libsodium` exit_status is expected to eq 0
     ✔  Command: `hab pkg path mindnumbing/libsodium` stdout is expected not to be empty
     ✔  Command: `hab pkg path mindnumbing/libsodium` stderr is expected to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libsodium/1.0.18/20200610115615/include` stdout is expected not to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libsodium/1.0.18/20200610115615/include` stderr is expected to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libsodium/1.0.18/20200610115615/include` exit_status is expected to eq 0
     ✔  Command: `ls /hab/pkgs/mindnumbing/libsodium/1.0.18/20200610115615/lib` stdout is expected not to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libsodium/1.0.18/20200610115615/lib` stderr is expected to be empty
     ✔  Command: `ls /hab/pkgs/mindnumbing/libsodium/1.0.18/20200610115615/lib` exit_status is expected to eq 0


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 9 successful, 0 failures, 0 skipped

Signed-off-by: Steven Marshall <SMarshall@chef.io>